### PR TITLE
Typo described in GATv2AttentionPool

### DIFF
--- a/tensorflow_gnn/graph/keras/layers/gat/gatv2.py
+++ b/tensorflow_gnn/graph/keras/layers/gat/gatv2.py
@@ -200,7 +200,7 @@ class GATv2(tf.keras.layers.Layer):
 class GATv2AttentionPool(tf.keras.layers.Layer):
   """GATv2 multi-head attention pooling.
 
-  Implements the pooling layer describe in https://arxiv.org/abs/2105.14491
+  Implements the pooling layer described in https://arxiv.org/abs/2105.14491
   Equations (3) and (4). That is, given the edge values, this layer computes the
   attention coefficients and multiplies them by the edges, and aggregates these
   by summing them on a per-node basis.


### PR DESCRIPTION
GATv2AttentionPool has a typo in the docstring.