### PR TITLE
rm sampling_spec_pb2.py from package/BUILD

### DIFF
--- a/package/BUILD
+++ b/package/BUILD
@@ -14,7 +14,6 @@ sh_binary(
         "//tensorflow_gnn/proto:examples_pb2.py",
         "//tensorflow_gnn/proto:graph_schema_pb2.py",
         "//tensorflow_gnn/sampler:subgraph_pb2.py",
-        "//tensorflow_gnn/sampler:sampling_spec_pb2.py",
         "//tensorflow_gnn/tools:sampled_stats_pb2.py",
     ],
 )


### PR DESCRIPTION
At this time, it is mandatory remove this line to install the package.