### PR TITLE
Update setup.py to use generic apache-beam dependency instead of apache-beam[gcp].

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ setup(
     ],
     namespace_packages=[],
     install_requires=[
-        'apache-beam[gcp]==2.33.0',  # TODO(b/238522209) Upgrade beam dep
+        'apache-beam',  # TODO(b/238522209) Upgrade beam dep
         'networkx',
         'pyarrow',
         'tensorflow>=2.7.0',


### PR DESCRIPTION
This should alleviate installation issues caused by https://github.com/apache/beam/issues/22218#issue-1300575577 while still allowing us to test locally.