### PR TITLE
mixed precision fix for runner

### DIFF
--- a/tensorflow_gnn/runner/trainers/keras_fit.py
+++ b/tensorflow_gnn/runner/trainers/keras_fit.py
@@ -269,14 +269,6 @@ class KerasTrainer(interfaces.Trainer):
     with self._strategy.scope():
       model = model_fn()
 
-    if self._options and self._options.policy:
-      # Cast logits to `tf.keras.backend.floatx()` for mixed_precision.
-      # For more details, see:
-      # https://www.tensorflow.org/guide/mixed_precision#building_the_model.
-      floatx = tf.keras.backend.floatx()
-      outputs = [tf.cast(o, dtype=floatx) for o in model.outputs]
-      model = tf.keras.Model(model.inputs, outputs)
-
     model.fit(
         train_ds,
         epochs=epochs,


### PR DESCRIPTION
Mixed precision training was not working with the runner. Casting of the output layer was occurring after model compilation. It has been moved into adapted_model_fn so that it occurs before calling model.compile()