### PR TITLE
Fix GraphUpdate from_config for nested serialized layers (improves Keras / tfmot compatibility)

### DIFF
--- a/tensorflow_gnn/keras/layers/graph_update.py
+++ b/tensorflow_gnn/keras/layers/graph_update.py
@@ -214,8 +214,26 @@ class GraphUpdate(tf.keras.layers.Layer):
 
   @classmethod
   def from_config(cls, config):
+    config = config.copy()
+
     config["edge_sets"] = du.pop_by_prefix(config, "edge_sets/")
     config["node_sets"] = du.pop_by_prefix(config, "node_sets/")
+
+    edge_sets = config.get("edge_sets") or {}
+    config["edge_sets"] = {
+        key: _maybe_deserialize_layer(value)
+        for key, value in edge_sets.items()
+    }
+
+    node_sets = config.get("node_sets") or {}
+    config["node_sets"] = {
+        key: _maybe_deserialize_layer(value)
+        for key, value in node_sets.items()
+    }
+
+    if config.get("context") is not None:
+      config["context"] = _maybe_deserialize_layer(config["context"])
+
     return cls(**config)
 
   def call(self, graph: gt.GraphTensor) -> gt.GraphTensor:
@@ -318,6 +336,15 @@ class EdgeSetUpdate(tf.keras.layers.Layer):
         node_input_feature=self._node_input_feature,
         context_input_feature=self._context_input_feature,
         **super().get_config())
+  
+  @classmethod
+  def from_config(cls, config):
+    config = config.copy()
+
+    if config.get("next_state") is not None:
+      config["next_state"] = _maybe_deserialize_layer(config["next_state"])
+
+    return cls(**config)
 
   def call(self, graph: gt.GraphTensor,
            edge_set_name: const.EdgeSetName) -> gt.GraphTensor:
@@ -415,7 +442,19 @@ class NodeSetUpdate(tf.keras.layers.Layer):
 
   @classmethod
   def from_config(cls, config):
+    config = config.copy()
+
     config["edge_set_inputs"] = du.pop_by_prefix(config, "edge_set_inputs/")
+
+    edge_set_inputs = config.get("edge_set_inputs") or {}
+    config["edge_set_inputs"] = {
+        key: _maybe_deserialize_layer(value)
+        for key, value in edge_set_inputs.items()
+    }
+
+    if config.get("next_state") is not None:
+      config["next_state"] = _maybe_deserialize_layer(config["next_state"])
+
     return cls(**config)
 
   def call(self, graph: gt.GraphTensor,
@@ -516,9 +555,26 @@ class ContextUpdate(tf.keras.layers.Layer):
 
   @classmethod
   def from_config(cls, config):
+    config = config.copy()
+
     config["node_set_inputs"] = du.pop_by_prefix(config, "node_set_inputs/")
-    config["edge_set_inputs"] = du.pop_by_prefix(config,
-                                                 "edge_set_inputs/") or None
+    config["edge_set_inputs"] = du.pop_by_prefix(config, "edge_set_inputs/")
+
+    node_set_inputs = config.get("node_set_inputs") or {}
+    config["node_set_inputs"] = {
+        key: _maybe_deserialize_layer(value)
+        for key, value in node_set_inputs.items()
+    }
+
+    edge_set_inputs = config.get("edge_set_inputs") or {}
+    config["edge_set_inputs"] = {
+        key: _maybe_deserialize_layer(value)
+        for key, value in edge_set_inputs.items()
+    }
+
+    if config.get("next_state") is not None:
+      config["next_state"] = _maybe_deserialize_layer(config["next_state"])
+
     return cls(**config)
 
   def call(self, graph: gt.GraphTensor) -> gt.GraphTensor:
@@ -575,4 +631,13 @@ def _check_is_layer(obj, description):
   if not isinstance(obj, tf.keras.layers.Layer):
     raise ValueError(f"{description} must be a tf.keras.layer.Layer, "
                      f"got type: {type(obj).__name__}")
+  return obj
+
+def _maybe_deserialize_layer(obj):
+  if isinstance(obj, tf.keras.layers.Layer):
+    return obj
+
+  if isinstance(obj, dict) and "class_name" in obj and "config" in obj:
+    return tf.keras.layers.deserialize(obj)
+
   return obj

--- a/tensorflow_gnn/keras/layers/graph_update_test.py
+++ b/tensorflow_gnn/keras/layers/graph_update_test.py
@@ -198,6 +198,85 @@ class GraphUpdateTest(tf.test.TestCase, parameterized.TestCase):
     self.assertAllEqual([[16. + 2.+ 19.]],
                         graph.context[const.HIDDEN_STATE])
 
+class GraphUpdateSerializationTest(tf.test.TestCase):
+
+  def test_graph_update_from_config_deserializes_nested_layers(self):
+    edge_next_state = next_state_lib.NextStateFromConcat(
+        tf.keras.layers.Dense(4, name="edge_dense")
+    )
+    node_next_state = next_state_lib.NextStateFromConcat(
+        tf.keras.layers.Dense(4, name="node_dense")
+    )
+
+    layer = graph_update.GraphUpdate(
+        edge_sets={
+            "edge": graph_update.EdgeSetUpdate(
+                next_state=edge_next_state,
+                node_input_tags=[const.SOURCE, const.TARGET],
+                edge_input_feature=const.HIDDEN_STATE,
+                context_input_feature=None,
+                name="edge_set_update",
+            )
+        },
+        node_sets={
+            "node": graph_update.NodeSetUpdate(
+                edge_set_inputs={
+                    "edge": graph_ops.Pool(const.TARGET, "sum")
+                },
+                next_state=node_next_state,
+                context_input_feature=None,
+                name="node_set_update",
+            )
+        },
+        context=None,
+        name="graph_update",
+    )
+
+    config = layer.get_config()
+    rebuilt = graph_update.GraphUpdate.from_config(config)
+
+    self.assertIsInstance(rebuilt, graph_update.GraphUpdate)
+
+    rebuilt_config = rebuilt.get_config()
+    self.assertIn("edge_sets/edge", rebuilt_config)
+    self.assertIn("node_sets/node", rebuilt_config)
+
+  def test_edge_set_update_from_config_deserializes_next_state(self):
+    layer = graph_update.EdgeSetUpdate(
+        next_state=next_state_lib.NextStateFromConcat(
+            tf.keras.layers.Dense(4, name="edge_dense")
+        ),
+        node_input_tags=[const.SOURCE],
+        edge_input_feature=const.HIDDEN_STATE,
+        name="edge_set_update",
+    )
+
+    config = layer.get_config()
+    rebuilt = graph_update.EdgeSetUpdate.from_config(config)
+
+    self.assertIsInstance(rebuilt, graph_update.EdgeSetUpdate)
+    rebuilt_config = rebuilt.get_config()
+    self.assertIn("next_state", rebuilt_config)
+
+  def test_node_set_update_from_config_deserializes_nested_layers(self):
+    layer = graph_update.NodeSetUpdate(
+        edge_set_inputs={
+            "edge": graph_ops.Pool(const.TARGET, "sum")
+        },
+        next_state=next_state_lib.NextStateFromConcat(
+            tf.keras.layers.Dense(4, name="node_dense")
+        ),
+        context_input_feature=None,
+        name="node_set_update",
+    )
+
+    config = layer.get_config()
+    rebuilt = graph_update.NodeSetUpdate.from_config(config)
+
+    self.assertIsInstance(rebuilt, graph_update.NodeSetUpdate)
+    rebuilt_config = rebuilt.get_config()
+    self.assertIn("edge_set_inputs/edge", rebuilt_config)
+    self.assertIn("next_state", rebuilt_config)
 
 def _make_test_graph_with_singleton_node_sets(nodes, edges, context=None):
   """Returns graph with singleton node sets and edge sets of given values."""


### PR DESCRIPTION
**Summary**

This PR makes several TF‑GNN Keras layers (`GraphUpdate`, `EdgeSetUpdate`, `NodeSetUpdate`, `ContextUpdate`) more robust when reconstructed from serialized configs, especially in setups where tooling such as `tfmot.quantization.keras` serializes nested layers as config dicts instead of already-instantiated `Layer` objects.  

The constructors and `_check_is_layer(...)` contract are unchanged; only `from_config(...)` paths are made tolerant to seeing serialized sub‑layer configs and normalize them back to `tf.keras.layers.Layer` instances before calling `__init__`.

***

**Problem**

In some environments (e.g. TF 2.16 + `tf-keras` + tfmot QAT), the following pattern can occur:

- A model containing TF‑GNN layers (e.g. `GraphUpdate`) is cloned/serialized via Keras (`clone_model`, `model.to_json`, etc.).  
- Nested sub‑layers (e.g. `EdgeSetUpdate`, `NodeSetUpdate.next_state`, context/node/edge inputs) are stored in the config as dicts of the form `{class_name, config, ...}` rather than as `Layer` instances.  
- Later, Keras calls `GraphUpdate.from_config(config)` / `EdgeSetUpdate.from_config(config)`. The corresponding `__init__` implementations still expect actual `Layer` objects and call `_check_is_layer(...)`, leading to errors like:

> `GraphUpdate(edge_sets={edge: ...}) must be a tf.keras.layer.Layer, got type: dict`  
> `EdgeSetUpdate(next_state=...) must be a tf.keras.layer.Layer, got type: dict.`

This makes it difficult to combine TF‑GNN models with tooling that relies on cloning and graph transformations via Keras configs (e.g. QAT with tfmot).

***

**Approach**

The idea is to leave `_check_is_layer(...)` and the type guarantees in the constructors unchanged, and instead make `from_config(...)` smart enough to recognize serialized Keras layers and deserialize them back into `Layer` instances.

1. Introduce a small helper:

```python
def _maybe_deserialize_layer(obj):
  if isinstance(obj, tf.keras.layers.Layer):
    return obj
  if isinstance(obj, dict) and "class_name" in obj and "config" in obj:
    return tf.keras.layers.deserialize(obj)
  return obj
```

2. Update the `from_config(...)` methods:

- **GraphUpdate**

  - Keep the existing `du.pop_by_prefix` logic:

    ```python
    config["edge_sets"] = du.pop_by_prefix(config, "edge_sets/")
    config["node_sets"] = du.pop_by_prefix(config, "node_sets/")
    ```

  - After that, run `_maybe_deserialize_layer` on:
    - each value in `config["edge_sets"]` and `config["node_sets"]`;  
    - `config["context"]` (if present).

- **EdgeSetUpdate**

  - Add a custom `from_config` that:
    - copies the config;  
    - applies `_maybe_deserialize_layer` to `config["next_state"]` (if present);  
    - calls `cls(**config)`.

- **NodeSetUpdate**

  - Extend `from_config` to:
    - call `du.pop_by_prefix(config, "edge_set_inputs/")` as before;  
    - run `_maybe_deserialize_layer` on each `edge_set_inputs[...]`;  
    - run `_maybe_deserialize_layer` on `next_state` (if present).

- **ContextUpdate**

  - Extend `from_config` to:
    - call `du.pop_by_prefix` on `node_set_inputs/*` and `edge_set_inputs/*`;  
    - run `_maybe_deserialize_layer` on each `node_set_inputs[...]` and `edge_set_inputs[...]`;  
    - run `_maybe_deserialize_layer` on `next_state` (if present).

In all cases, `_check_is_layer(...)` in the constructors is unchanged and will still reject non‑Layer values that could not be normalized.

***

**Rationale / why this is safe**

- We do **not** change runtime call semantics or relax any type checks. All constructors still require actual `tf.keras.layers.Layer` instances and `_check_is_layer(...)` continues to enforce that.  
- Only `from_config(...)` code paths are touched, i.e. reconstruction from serialized configs (`load_model`, `clone_model`, etc.), not ordinary model building.  
- `_maybe_deserialize_layer(...)` is conservative:
  - if `obj` is already a `Layer`, it is returned as‑is;  
  - if `obj` is a dict with `class_name` and `config`, it matches the standard Keras serialization format and is deserialized via `tf.keras.layers.deserialize`;  
  - in all other cases `obj` is left unchanged and `_check_is_layer(...)` will still raise if it is not a `Layer`.

The pattern is applied consistently across `GraphUpdate`, `EdgeSetUpdate`, `NodeSetUpdate` and `ContextUpdate`, which makes future maintenance and reasoning about serialization behavior easier.

***

**Tests**

- **New tests** in `tensorflow_gnn/keras/layers/graph_update_test.py`:

  - `GraphUpdateSerializationTest.test_graph_update_from_config_deserializes_nested_layers`  
    - Constructs a `GraphUpdate` with nested `EdgeSetUpdate` / `NodeSetUpdate` using TF‑GNN layers (including `Pool` and `NextStateFromConcat`), calls `get_config()` and `GraphUpdate.from_config(config)`, and asserts the rebuilt instance is a `GraphUpdate` whose `get_config()` still contains keys like `"edge_sets/edge"` and `"node_sets/node"`.

  - `GraphUpdateSerializationTest.test_edge_set_update_from_config_deserializes_next_state`  
    - Verifies that `EdgeSetUpdate.from_config(...)` correctly restores `next_state` and that `get_config()` on the rebuilt layer includes `"next_state"`.

  - `GraphUpdateSerializationTest.test_node_set_update_from_config_deserializes_nested_layers`  
    - Verifies that `NodeSetUpdate.from_config(...)` correctly restores `edge_set_inputs` and `next_state`, and that `get_config()` on the rebuilt layer includes `"edge_set_inputs/edge"` and `"next_state"`.

- **Existing tests** in `graph_update_test.py` continue to pass.

- All tests were run under a fresh virtualenv with TensorFlow 2.16+, `tensorflow-gnn` 1.0.3 and `tf-keras`, with:

  ```bash
  TF_USE_LEGACY_KERAS=1 python -m tensorflow_gnn.keras.layers.graph_update_test
  ```